### PR TITLE
Add strict mode option

### DIFF
--- a/plugins/modules/yamale_validate.py
+++ b/plugins/modules/yamale_validate.py
@@ -35,6 +35,12 @@ options:
           - path to the YAML file you want to validate
         required: true
         type: str
+    strict:
+        description:
+          - Disabled strict mode allows additional fields to be present that are not defined in the schema
+        required: false
+        type: bool
+        default: true
 '''
 
 EXAMPLES = r'''
@@ -73,9 +79,9 @@ def load_schema(schema_path):
     return yamale.make_schema(schema_path)
 
 
-def validate_yaml(data, schema):
+def validate_yaml(data, schema, strict):
     try:
-        yamale.validate(schema, data)
+        yamale.validate(schema, data, strict=strict)
         return True, ""
     except ValueError as e:
         return False, str(e)
@@ -84,7 +90,8 @@ def validate_yaml(data, schema):
 def main():
     module_args = dict(
         data_path=dict(type='str', required=True),
-        schema_path=dict(type='str', required=True)
+        schema_path=dict(type='str', required=True),
+        strict=dict(type='bool', required=False, default=True)
     )
 
     module = AnsibleModule(
@@ -104,7 +111,9 @@ def main():
     except FileNotFoundError:
         module.fail_json(msg='Schema file {} not found'.format(module.params['schema_path']))
 
-    yamale_result, message = validate_yaml(data, schema)
+    strict_mode = module.params['strict']
+
+    yamale_result, message = validate_yaml(data, schema, strict_mode)
 
     result = dict(
         changed=False,

--- a/tests/data_additional_field.yaml
+++ b/tests/data_additional_field.yaml
@@ -1,0 +1,14 @@
+---
+
+test_string: "test"
+
+test_integer: 56
+
+test_ip_address: "192.168.10.5/32"
+
+test_list:
+  - 1
+  - 2
+  - 3
+
+additional_field: True

--- a/tests/test_yamale_validate.py
+++ b/tests/test_yamale_validate.py
@@ -33,3 +33,32 @@ def test_invalid_yaml(module_args):
         yamale_validate.main()
 
     assert (result.value.args[0]['changed'] is False)
+
+
+def test_yaml_with_additional_fields_fails_in_strict_mode(module_args):
+    import yamale_validate
+
+    set_module_args({
+        **module_args,
+        "data_path": "tests/data_additional_field.yaml"
+    })
+
+    with raises(AnsibleFailJson) as result:
+        yamale_validate.main()
+
+    assert (result.value.args[0]['changed'] is False)
+
+
+def test_yaml_with_additional_fields_fails_in_strict_mode(module_args):
+    import yamale_validate
+
+    set_module_args({
+        **module_args,
+        "data_path": "tests/data_additional_field.yaml",
+        "strict": False
+    })
+
+    with raises(AnsibleExitJson) as result:
+        yamale_validate.main()
+
+    assert (result.value.args[0]['changed'] is False)


### PR DESCRIPTION
This adds an option to disable the strict mode of yamale. If strict mode is disabled, additional variables can be present in the yaml, which are not included in the schema.
The new argument is not required and the default is strict mode enabled (which is also the yamale default).